### PR TITLE
Fixed layout by removing blank space below username/password table + other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.gem
 builds/
 builds/*
+Gemfile.lock
+.ruby-version
+.ruby-gemset
+.gladiator
+.gladiator-scratchpad

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'bcrypt'
-gem 'glimmer-dsl-libui'
-gem 'rbnacl'
+gem 'glimmer-dsl-libui', '0.11.5'
+gem 'httparty', '0.21.0'
+gem 'rbnacl', '~> 7.1'
 gem 'rubocop', require: false

--- a/bin/adamantite
+++ b/bin/adamantite
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+$LOAD_PATH.unshift File.expand_path(File.join(__dir__, '..', 'lib'))
+
 require 'adamantite'
 
 Adamantite::AdamantiteApp.launch

--- a/lib/adamantite.rb
+++ b/lib/adamantite.rb
@@ -121,6 +121,8 @@ module Adamantite
               cell_rows <=> [self, :stored_passwords]
             end
             horizontal_box do
+              stretchy false
+              
               button('Add Password') do
                 on_clicked do
                   on_save = lambda do |password_object|
@@ -144,6 +146,8 @@ module Adamantite
               end
             end
             horizontal_box do
+              stretchy false
+              
               label('This is valid Adamantite installation.')
             end
           end

--- a/lib/adamantite.rb
+++ b/lib/adamantite.rb
@@ -59,6 +59,8 @@ module Adamantite
           msg_box('Jake Bruemmer - https://x.com/jakebruemmer')
         end
       end
+      # following is needed for Mac to enable easy quitting with CMD+Q shortcut
+      quit_menu_item
     end
 
     body do


### PR DESCRIPTION
Change log:
- Fix the layout by removing unnecessary blank space below the username/password table
- Add quit menu item for Mac to enable easy quitting of app with CMD+Q shortcut
- Add lib to $LOAD_PATH in bin/adamantite to enable local execution and testing directly from repo
- Add missing dependencies to Gemfile to enable local testing before packaging as a gem
- Update .gitignore to avoid committing unwanted but necessary local files